### PR TITLE
Feat/segment clip

### DIFF
--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -1,0 +1,3 @@
+# Operations Module
+
+::: soundevent.operations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - User Guide: generated/gallery
   - Reference:
       - data: reference/data.md
+      - operations: reference/operations.md
       - io: reference/io.md
       - arrays: reference/arrays.md
       - audio: reference/audio.md

--- a/src/soundevent/constants.py
+++ b/src/soundevent/constants.py
@@ -1,0 +1,10 @@
+"""Package wide constants."""
+
+import uuid
+
+__all__ = [
+    "uuid_namespace",
+]
+
+uuid_namespace = uuid.uuid5(uuid.NAMESPACE_DNS, "soundevent")
+"""UUID namespace for soundevent data."""

--- a/src/soundevent/operations.py
+++ b/src/soundevent/operations.py
@@ -89,13 +89,15 @@ def segment_clip(
     num_segments = math.floor(clip.duration / hop)
     for i in range(num_segments):
         start_time = clip.start_time + i * hop
-        end_time = min(start_time + duration, clip.end_time)
+        end_time = start_time + duration
 
         if start_time >= clip.end_time:
             break
 
-        if end_time >= clip.end_time and not include_incomplete:
+        if end_time > clip.end_time and not include_incomplete:
             break
+
+        end_time = min(end_time, clip.end_time)
 
         yield data.Clip(
             uuid=uuid.uuid5(

--- a/src/soundevent/operations.py
+++ b/src/soundevent/operations.py
@@ -1,0 +1,108 @@
+"""Operations Module.
+
+This module provides generic operations for manipulating sound event data.
+"""
+
+import math
+import uuid
+from collections.abc import Generator
+from typing import Optional
+
+from soundevent import data
+from soundevent.constants import uuid_namespace
+
+
+def segment_clip(
+    clip: data.Clip,
+    duration: float,
+    hop: Optional[float] = None,
+    include_incomplete: bool = False,
+) -> Generator[data.Clip, None, None]:
+    """Segments a clip into smaller clips of a specified duration.
+
+    This function iterates yields segments of a given duration, with a
+    specified hop size between segments. It can optionally include the last
+    segment even if it is shorter than the specified duration.
+
+    Parameters
+    ----------
+    clip
+        The input audio clip to be segmented.
+    duration
+        The duration of each segment in seconds.
+    hop
+        The hop size between segments in seconds. If None (default),
+        the hop size is set equal to the duration, resulting in
+        non-overlapping segments.
+    include_incomplete
+        Whether to include the last segment if it is shorter than
+        the specified duration. Defaults to False.
+
+    Yields
+    ------
+    data.Clip
+        A segmented clip with a unique UUID, start time, end time,
+        and the same recording as the input clip.
+
+    Raises
+    ------
+    ValueError
+        If the duration or hop size is negative or zero.
+
+    Notes
+    -----
+    If `include_incomplete` is True, the last segment might be shorter
+    than the specified duration, as its end time is clamped to the end
+    time of the input clip.
+
+    Examples
+    --------
+    >>> from soundevent import data
+    >>> clip = data.Clip(
+    ...     start_time=0.0,
+    ...     end_time=10.0,
+    ...     recording="...",
+    ... )
+    >>> segments = segment_clip(clip, duration=2.0, hop=1.0)
+    >>> for segment in segments:
+    ...     print(segment.start_time, segment.end_time)
+    0.0 2.0
+    1.0 3.0
+    2.0 4.0
+    3.0 5.0
+    4.0 6.0
+    5.0 7.0
+    6.0 8.0
+    7.0 9.0
+    8.0 10.0
+
+    """
+    if hop is None:
+        hop = duration
+
+    if duration <= 0:
+        raise ValueError("Duration must be positive.")
+
+    if hop <= 0:
+        raise ValueError("Hop size must be positive.")
+
+    num_segments = math.floor(clip.duration / hop)
+    for i in range(num_segments):
+        start_time = clip.start_time + i * hop
+        end_time = min(start_time + duration, clip.end_time)
+
+        if start_time >= clip.end_time:
+            break
+
+        if end_time >= clip.end_time and not include_incomplete:
+            break
+
+        yield data.Clip(
+            uuid=uuid.uuid5(
+                uuid_namespace,
+                f"segment_clip:{clip.uuid}:{start_time}:{end_time}",
+            ),
+            start_time=start_time,
+            end_time=end_time,
+            recording=clip.recording,
+        )

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,105 @@
+import pytest
+
+from soundevent import data
+from soundevent.operations import segment_clip
+
+
+def test_segment_clip_no_hop(recording: data.Recording):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=10.0,
+        recording=recording,
+    )
+    segments = list(segment_clip(clip, duration=2.0))
+    assert len(segments) == 5
+    for i, segment in enumerate(segments):
+        assert segment.start_time == i * 2.0
+        assert segment.end_time == (i + 1) * 2.0
+        assert segment.duration == 2.0
+
+
+def test_segment_clip_with_hop(recording: data.Recording):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=10.0,
+        recording=recording,
+    )
+    segments = list(segment_clip(clip, duration=2.0, hop=1.0))
+    assert len(segments) == 9
+    for i, segment in enumerate(segments):
+        assert segment.start_time == i * 1.0
+        assert segment.end_time == i * 1.0 + 2.0
+        assert segment.duration == 2.0
+
+
+def test_segment_clip_include_incomplete(recording: data.Recording):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=10.0,
+        recording=recording,
+    )
+    segments = list(
+        segment_clip(clip, duration=3.0, hop=2.0, include_incomplete=True)
+    )
+    assert len(segments) == 5
+    assert [(s.start_time, s.end_time) for s in segments] == [
+        (0, 3),
+        (2, 5),
+        (4, 7),
+        (6, 9),
+        (8, 10),
+    ]
+
+
+def test_segment_clip_exclude_incomplete(recording: data.Recording):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=10.0,
+        recording=recording,
+    )
+    segments = list(
+        segment_clip(clip, duration=3.0, hop=2.0, include_incomplete=False)
+    )
+    assert [(s.start_time, s.end_time) for s in segments] == [
+        (0, 3),
+        (2, 5),
+        (4, 7),
+        (6, 9),
+    ]
+
+
+def test_segment_clip_invalid_input(recording: data.Recording):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=10.0,
+        recording=recording,
+    )
+    with pytest.raises(ValueError):
+        list(segment_clip(clip, duration=0.0))
+    with pytest.raises(ValueError):
+        list(segment_clip(clip, duration=2.0, hop=-1.0))
+
+
+def test_segment_clip_empty_clip(recording: data.Recording):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=0.0,
+        recording=recording,
+    )
+    segments = list(segment_clip(clip, duration=2.0))
+    assert len(segments) == 0
+
+
+def test_segment_clip_uuid_generation_is_deterministic(
+    recording: data.Recording,
+):
+    clip = data.Clip(
+        start_time=0.0,
+        end_time=10.0,
+        recording=recording,
+    )
+    segments1 = list(segment_clip(clip, duration=2.0, hop=1.0))
+    segments2 = list(segment_clip(clip, duration=2.0, hop=1.0))
+
+    for segment1, segment2 in zip(segments1, segments2):
+        assert segment1.uuid == segment2.uuid

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -11,11 +11,13 @@ def test_segment_clip_no_hop(recording: data.Recording):
         recording=recording,
     )
     segments = list(segment_clip(clip, duration=2.0))
-    assert len(segments) == 5
-    for i, segment in enumerate(segments):
-        assert segment.start_time == i * 2.0
-        assert segment.end_time == (i + 1) * 2.0
-        assert segment.duration == 2.0
+    assert [(s.start_time, s.end_time) for s in segments] == [
+        (0, 2),
+        (2, 4),
+        (4, 6),
+        (6, 8),
+        (8, 10),
+    ]
 
 
 def test_segment_clip_with_hop(recording: data.Recording):
@@ -25,11 +27,17 @@ def test_segment_clip_with_hop(recording: data.Recording):
         recording=recording,
     )
     segments = list(segment_clip(clip, duration=2.0, hop=1.0))
-    assert len(segments) == 9
-    for i, segment in enumerate(segments):
-        assert segment.start_time == i * 1.0
-        assert segment.end_time == i * 1.0 + 2.0
-        assert segment.duration == 2.0
+    assert [(s.start_time, s.end_time) for s in segments] == [
+        (0, 2),
+        (1, 3),
+        (2, 4),
+        (3, 5),
+        (4, 6),
+        (5, 7),
+        (6, 8),
+        (7, 9),
+        (8, 10),
+    ]
 
 
 def test_segment_clip_include_incomplete(recording: data.Recording):
@@ -41,7 +49,6 @@ def test_segment_clip_include_incomplete(recording: data.Recording):
     segments = list(
         segment_clip(clip, duration=3.0, hop=2.0, include_incomplete=True)
     )
-    assert len(segments) == 5
     assert [(s.start_time, s.end_time) for s in segments] == [
         (0, 3),
         (2, 5),

--- a/uv.lock
+++ b/uv.lock
@@ -1635,8 +1635,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
-    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },
@@ -1820,15 +1818,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.383"
+version = "1.1.385"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/a9/4654d15f4125d8dca6318d7be36a3283a8b3039661291c59bbdd1e576dcf/pyright-1.1.383.tar.gz", hash = "sha256:1df7f12407f3710c9c6df938d98ec53f70053e6c6bbf71ce7bcb038d42f10070", size = 21971 }
+sdist = { url = "https://files.pythonhosted.org/packages/29/ca/3238db97766ecfd6b2758fb50727a0b433e7b1bb6be0de090ed08b291fff/pyright-1.1.385.tar.gz", hash = "sha256:1bf042b8f080441534aa02101dea30f8fc2efa8f7b6f1ab05197c21317f5bfa7", size = 21971 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/55/40a6559cea209b551c81dcd31cb351a6ffdb5876e7865ee242e269af72d8/pyright-1.1.383-py3-none-any.whl", hash = "sha256:d864d1182a313f45aaf99e9bfc7d2668eeabc99b29a556b5344894fd73cb1959", size = 18577 },
+    { url = "https://files.pythonhosted.org/packages/e3/39/877484412a1079003a7645375b487bd7c422692f4e5b7c2030dea3e83043/pyright-1.1.385-py3-none-any.whl", hash = "sha256:e5b9a1b8d492e13004d822af94d07d235f2c7c158457293b51ab2214c8c5b375", size = 18579 },
 ]
 
 [[package]]
@@ -2419,7 +2417,7 @@ wheels = [
 
 [[package]]
 name = "soundevent"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "email-validator" },


### PR DESCRIPTION
This PR introduces a new function, `soundevent.operations.segment_clip`, designed to generate subclips from a given audio clip using a rolling window approach. 

This addresses a common need in audio processing, making it a valuable addition to the `soundevent` library. To accommodate this and future generic operations on `soundevent.data` objects, a new module, `soundevent.operations`, has been created.