### PR TITLE
Feat/Add `is_in_clip` function to `soundevent.geometry.operations`

### DIFF
--- a/src/soundevent/geometry/__init__.py
+++ b/src/soundevent/geometry/__init__.py
@@ -20,6 +20,7 @@ from soundevent.geometry.operations import (
     buffer_geometry,
     compute_bounds,
     get_geometry_point,
+    is_in_clip,
     rasterize,
 )
 
@@ -31,4 +32,5 @@ __all__ = [
     "geometry_to_shapely",
     "get_geometry_point",
     "rasterize",
+    "is_in_clip",
 ]


### PR DESCRIPTION
This PR introduces a new function, `soundevent.geometry.operations.is_in_clip`, which determines if a given geometry lies within the temporal boundaries of an audio clip. This functionality is common for various audio analysis and processing tasks where the presence of an events within audio segments need to be established.

The new function `is_in_clip(geometry, clip, minimum_overlap=0)` checks if a `data.Geometry` object falls within the time range of a `data.Clip` object. Allows specifying a `minimum_overlap` parameter (in seconds) to control the required amount of temporal overlap for the geometry to be considered inside the clip.