### PR TITLE
Feat/Add `adjust_dim_range` function to `soundevent.arrays.operations`

### DIFF
--- a/src/soundevent/arrays/__init__.py
+++ b/src/soundevent/arrays/__init__.py
@@ -22,6 +22,7 @@ from soundevent.arrays.dimensions import (
     set_dim_attrs,
 )
 from soundevent.arrays.operations import (
+    adjust_dim_range,
     crop_dim,
     extend_dim,
     normalize,
@@ -49,4 +50,5 @@ __all__ = [
     "set_dim_attrs",
     "set_value_at_pos",
     "to_db",
+    "adjust_dim_range",
 ]

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -483,7 +483,7 @@ def is_in_clip(
     Returns
     -------
     bool
-        True if the geometry is within the clip with the specified 
+        True if the geometry is within the clip with the specified
         minimum overlap, False otherwise.
 
     Raises


### PR DESCRIPTION
This PR introduces a new function, `soundevent.arrays.operations.adjust_dim_range`, to provide a generic way to adjust the range of a specified dimension in an xarray DataArray. This functionality is useful for various data manipulation tasks, such as cropping, extending, or aligning data along a particular dimension.

The function `adjust_dim_range(array, dim, start=None, stop=None, fill_value=0, eps=1e-4)` modifies the range of the given `dim` in the input `array` to match the desired `start` and `stop` values. The function handles cases where the original range needs to be cropped or extended. It uses `fill_value` to fill in missing data when extending the range.
