### PR TITLE
Feat/Add functions for sound event grouping

### DIFF
--- a/src/soundevent/geometry/__init__.py
+++ b/src/soundevent/geometry/__init__.py
@@ -20,6 +20,9 @@ from soundevent.geometry.operations import (
     buffer_geometry,
     compute_bounds,
     get_geometry_point,
+    group_sound_events,
+    have_frequency_overlap,
+    intervals_overlap,
     is_in_clip,
     rasterize,
 )
@@ -31,6 +34,10 @@ __all__ = [
     "geometry_to_html",
     "geometry_to_shapely",
     "get_geometry_point",
-    "rasterize",
+    "group_sound_events",
+    "have_frequency_overlap",
+    "have_frequency_overlap",
+    "intervals_overlap",
     "is_in_clip",
+    "rasterize",
 ]

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -1,13 +1,26 @@
 """Functions that handle SoundEvent geometries."""
 
 import json
-from typing import Any, List, Literal, Optional, Tuple, Union
+from collections import defaultdict
+from itertools import combinations
+from typing import (
+    Any,
+    Callable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import shapely
 import xarray as xr
 from numpy.typing import DTypeLike
 from rasterio import features
+from scipy import sparse
+from scipy.sparse.csgraph import connected_components
 
 from soundevent import data
 from soundevent.arrays import (
@@ -20,9 +33,13 @@ from soundevent.geometry.conversion import geometry_to_shapely
 __all__ = [
     "buffer_geometry",
     "compute_bounds",
-    "rasterize",
     "get_geometry_point",
+    "group_sound_events",
+    "have_frequency_overlap",
+    "have_temporal_overlap",
+    "intervals_overlap",
     "is_in_clip",
+    "rasterize",
 ]
 
 
@@ -703,4 +720,102 @@ def have_frequency_overlap(
         (low_freq_2, high_freq_2),
         min_absolute_overlap=min_absolute_overlap,
         min_relative_overlap=min_relative_overlap,
+    )
+
+
+def group_sound_events(
+    sound_events: Sequence[data.SoundEvent],
+    comparison_fn: Callable[[data.SoundEvent, data.SoundEvent], bool],
+) -> list[data.Sequence]:
+    """Group sound events into sequences based on a pairwise comparison.
+
+    This function takes a sequence of `data.SoundEvent` objects and a
+    comparison function. It applies the comparison function to all pairs
+    of sound events to determine their similarity. Sound events that are
+    deemed similar are grouped together into `data.Sequence` objects.
+
+    The comparison function should take two `data.SoundEvent` objects as
+    input and return True if they are considered similar, and False
+    otherwise.
+
+    Parameters
+    ----------
+    sound_events : Sequence[data.SoundEvent]
+        A sequence of `data.SoundEvent` objects to be grouped.
+    comparison_fn : Callable[[data.SoundEvent, data.SoundEvent], bool]
+        A function that compares two `data.SoundEvent` objects and
+        returns True if they should be grouped together, False otherwise.
+
+    Returns
+    -------
+    list[data.Sequence]
+        A list of `data.Sequence` objects, where each sequence contains
+        a group of similar sound events.
+
+    Notes
+    -----
+    This function groups sound events based on **transitive similarity**. While
+    it uses pairwise comparisons, the final groups (sequences) can include
+    sound events that aren't directly similar according to your
+    `comparison_fn`. Think of it like a chain:  sound event A is similar to B,
+    B is similar to C, but A might not be similar to C directly. They all end
+    up in the same group because of their connections through B. Technically,
+    this works by finding the connected components in a graph where the sound
+    events are nodes, and the edges represent similarity based on your
+    `comparison_fn`.
+
+    Examples
+    --------
+    >>> # Define a comparison function based on temporal overlap
+    >>> def compare_sound_events(se1, se2):
+    ...     return have_temporal_overlap(
+    ...         se1.geometry, se2.geometry, min_absolute_overlap=0.5
+    ...     )
+    >>> # Group sound events with the comparison function
+    >>> sequences = group_sound_events(
+    ...     sound_events, compare_sound_events
+    ... )
+    """
+    similarity_matrix = _compute_similarity_matrix(
+        sound_events,
+        comparison_fn,
+    )
+    _, labels = connected_components(similarity_matrix)
+
+    sequences = defaultdict(data.Sequence)
+    for sound_event, label in zip(sound_events, labels):
+        sequence = sequences[label]
+        sequence.sound_events.append(sound_event)
+
+    return list(sequences.values())
+
+
+def _compute_similarity_matrix(
+    sound_events: Sequence[data.SoundEvent],
+    comparison_fn: Callable[[data.SoundEvent, data.SoundEvent], bool],
+) -> sparse.coo_array:
+    """Compute the similarity matrix for sound events.
+
+    This helper function generates a sparse similarity matrix
+    representing the pairwise similarity between sound events based on
+    the provided comparison function.
+    """
+    col = []
+    row = []
+    values = []
+    for (index1, se1), (index2, se2) in combinations(
+        enumerate(sound_events), 2
+    ):
+        if not comparison_fn(se1, se2):
+            continue
+
+        col.extend([index1, index2])
+        row.extend([index2, index1])
+        values.extend([1, 1])
+
+    rows = len(sound_events)
+    return sparse.coo_array(
+        (values, (col, row)),
+        shape=(rows, rows),
+        dtype=np.int8,
     )

--- a/tests/test_geometry/test_operations.py
+++ b/tests/test_geometry/test_operations.py
@@ -13,6 +13,7 @@ from soundevent.geometry.operations import (
     buffer_geometry,
     compute_bounds,
     get_geometry_point,
+    group_sound_events,
     have_frequency_overlap,
     have_temporal_overlap,
     is_in_clip,
@@ -473,3 +474,107 @@ def test_have_frequency_overlap_invalid_input():
         have_frequency_overlap(geom1, geom2, min_relative_overlap=-0.5)
     with pytest.raises(ValueError):
         have_frequency_overlap(geom1, geom2, min_relative_overlap=1.5)
+
+
+def test_group_sound_events_no_events():
+    sound_events: list[data.SoundEvent] = []
+    sequences = group_sound_events(sound_events, lambda se1, se2: se1 == se2)
+    assert sequences == []
+
+
+def test_group_sound_events_all_similar(recording: data.Recording):
+    sound_events = [
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[1, 2]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[2, 3]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[3, 4]),
+        ),
+    ]
+    sequences = group_sound_events(sound_events, lambda se1, se2: True)
+    assert len(sequences) == 1
+    assert len(sequences[0].sound_events) == 3
+
+
+def test_group_sound_events_no_similar(recording: data.Recording):
+    sound_events = [
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[1, 2]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[2, 3]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[3, 4]),
+        ),
+    ]
+    sequences = group_sound_events(sound_events, lambda se1, se2: False)
+    assert len(sequences) == 3
+    for sequence in sequences:
+        assert len(sequence.sound_events) == 1
+
+
+def test_group_sound_events_some_similar(recording: data.Recording):
+    sound_events = [
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[1, 2]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[3, 4]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[3, 5]),
+        ),
+    ]
+
+    def comparison_fn(se1: data.SoundEvent, se2: data.SoundEvent):
+        if se1.geometry is None or se2.geometry is None:
+            return False
+        return have_temporal_overlap(se1.geometry, se2.geometry)
+
+    sequences = group_sound_events(sound_events, comparison_fn)
+    assert len(sequences) == 2
+    assert any(
+        len(sequence.sound_events) == 2 for sequence in sequences
+    )  # Group of 2 similar events
+    assert any(
+        len(sequence.sound_events) == 1 for sequence in sequences
+    )  # The remaining event
+
+
+def test_group_sound_events_transitive_similarity(recording: data.Recording):
+    sound_events = [
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[1, 3]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[2, 5]),
+        ),
+        data.SoundEvent(
+            recording=recording,
+            geometry=data.TimeInterval(coordinates=[4, 6]),
+        ),
+    ]
+
+    def comparison_fn(se1: data.SoundEvent, se2: data.SoundEvent):
+        if se1.geometry is None or se2.geometry is None:
+            return False
+        return have_temporal_overlap(se1.geometry, se2.geometry)
+
+    sequences = group_sound_events(sound_events, comparison_fn)
+    assert len(sequences) == 1
+    assert len(sequences[0].sound_events) == 3  # All in the same group


### PR DESCRIPTION
This PR introduces new functions to facilitate the grouping of sound events into sequences based on various similarity criteria. This is particularly useful when dealing with complex acoustic scenarios where multiple sound events might be related to the same source or individual.

**Motivation:**

- **Multiple components of a single source:**  Sound events representing different acoustic or harmonic components of the same source might occur in different frequency ranges. Grouping these events helps to analyze them collectively rather than as independent occurrences.
- **Repeated vocalizations:** When an individual produces repeated vocalizations (e.g., bat echolocation, cricket songs), the events might appear in the same frequency range but at different times. Grouping these events can help identify vocalizations from the same individual or species.

**New functions:**

- `soundevent.geometry.operations.group_sound_events`:
    - Takes a list of `data.SoundEvent` objects and a user-defined comparison function (`comparison_fn`).
    - Groups sound events into `data.Sequence` objects based on pairwise similarity determined by the `comparison_fn`.
- `soundevent.geometry.operations.have_temporal_overlap`:
    - Checks if two `data.Geometry` objects have temporal overlap, optionally considering minimum absolute or relative overlap thresholds.
- `soundevent.geometry.operations.have_frequency_overlap`:
    - Checks if two `data.Geometry` objects have frequency overlap, optionally considering minimum absolute or relative overlap thresholds.

**Example usage:**

```python
from soundevent import data
from soundevent.geometry.operations import (
    group_sound_events,
    have_temporal_overlap,
    have_frequency_overlap,
)

# Define a comparison function based on temporal and frequency overlap
def compare_sound_events(se1, se2):
    return (
        have_temporal_overlap(se1.geometry, se2.geometry, min_relative_overlap=0.5)
        and have_frequency_overlap(se1.geometry, se2.geometry, min_relative_overlap=0.8)
    )

# Group sound events
sequences = group_sound_events(sound_events, compare_sound_events)