### PR TITLE
Fix/serialize name and description

### DIFF
--- a/src/soundevent/io/aoef/annotation_project.py
+++ b/src/soundevent/io/aoef/annotation_project.py
@@ -11,8 +11,6 @@ class AnnotationProjectObject(AnnotationSetObject):
     """Schema definition for an annotation project object in AOEF format."""
 
     collection_type: ColType = "annotation_project"  # type: ignore
-    name: str
-    description: Optional[str] = None
     instructions: Optional[str] = None
     project_tags: Optional[List[int]] = None
     tasks: Optional[List[AnnotationTaskObject]] = None

--- a/src/soundevent/io/aoef/annotation_project.py
+++ b/src/soundevent/io/aoef/annotation_project.py
@@ -83,8 +83,6 @@ class AnnotationProjectAdapter(AnnotationSetAdapter):
                 if value is not None
             },
             tasks=tasks,
-            name=obj.name,
-            description=obj.description,
             instructions=obj.instructions,
             annotation_tags=[
                 tag

--- a/src/soundevent/io/aoef/annotation_set.py
+++ b/src/soundevent/io/aoef/annotation_set.py
@@ -25,6 +25,8 @@ from soundevent import data
 
 class AnnotationSetObject(BaseModel):
     uuid: UUID
+    name: Optional[str] = None
+    description: Optional[str] = None
     collection_type: Literal["annotation_set"] = "annotation_set"
     users: Optional[List[UserObject]] = None
     tags: Optional[List[TagObject]] = None
@@ -122,6 +124,8 @@ class AnnotationSetAdapter:
             sequence_annotations=self.sequence_annotations_adapter.values(),
             clip_annotations=annotated_clips,
             created_on=obj.created_on,
+            name=obj.name,
+            description=obj.description,
         )
 
     def to_soundevent(
@@ -163,6 +167,8 @@ class AnnotationSetAdapter:
 
         return data.AnnotationSet(
             uuid=obj.uuid or uuid4(),
+            name=obj.name,
+            description=obj.description,
             clip_annotations=annotated_clips,
             created_on=obj.created_on or datetime.datetime.now(),
         )

--- a/src/soundevent/io/aoef/evaluation_set.py
+++ b/src/soundevent/io/aoef/evaluation_set.py
@@ -52,8 +52,6 @@ class EvaluationSetAdapter(AnnotationSetAdapter):
                 for field, value in annotation_set
                 if value is not None
             },
-            name=obj.name,
-            description=obj.description,
             evaluation_tags=[
                 tag
                 for tag_id in obj.evaluation_tags or []

--- a/src/soundevent/io/aoef/evaluation_set.py
+++ b/src/soundevent/io/aoef/evaluation_set.py
@@ -8,8 +8,6 @@ class EvaluationSetObject(AnnotationSetObject):
     """Schema definition for an evaluation set object in AOEF format."""
 
     collection_type: Literal["evaluation_set"] = "evaluation_set"  # type: ignore
-    name: str
-    description: Optional[str] = None
     evaluation_tags: Optional[List[int]] = None
 
 

--- a/src/soundevent/io/aoef/model_run.py
+++ b/src/soundevent/io/aoef/model_run.py
@@ -15,8 +15,6 @@ class ModelInfoObject(BaseModel):
 
 class ModelRunObject(PredictionSetObject):
     collection_type: Literal["model_run"] = "model_run"  # type: ignore
-    name: str
-    description: Optional[str] = None
     model: Optional[ModelInfoObject] = None
 
     @computed_field

--- a/src/soundevent/io/aoef/prediction_set.py
+++ b/src/soundevent/io/aoef/prediction_set.py
@@ -25,6 +25,8 @@ from soundevent import data
 
 class PredictionSetObject(BaseModel):
     uuid: UUID
+    name: Optional[str] = None
+    description: Optional[str] = None
     created_on: Optional[datetime.datetime] = None
     collection_type: Literal["prediction_set"] = "prediction_set"
     users: Optional[List[UserObject]] = None
@@ -105,6 +107,8 @@ class PredictionSetAdapter:
 
         return PredictionSetObject(
             uuid=obj.uuid,
+            name=obj.name,
+            description=obj.description,
             created_on=obj.created_on,
             users=self.user_adapter.values(),
             tags=self.tag_adapter.values(),
@@ -149,6 +153,8 @@ class PredictionSetAdapter:
 
         return data.PredictionSet(
             uuid=obj.uuid or uuid4(),
+            name=obj.name,
+            description=obj.description,
             clip_predictions=clip_predictions,
             created_on=obj.created_on or datetime.datetime.now(),
         )

--- a/tests/test_io/test_aoef/test_annotation_set.py
+++ b/tests/test_io/test_aoef/test_annotation_set.py
@@ -1,6 +1,8 @@
 """Test Suite for AOEF Annotation Set Adapter."""
 
-from soundevent import data
+from pathlib import Path
+
+from soundevent import data, io
 from soundevent.io.aoef.annotation_set import (
     AnnotationSetAdapter,
     AnnotationSetObject,
@@ -22,3 +24,25 @@ def test_annotation_set_can_be_recovered(
     obj = annotation_set_adapter.to_aoef(annotation_set)
     recovered = annotation_set_adapter.to_soundevent(obj)
     assert annotation_set == recovered
+
+
+def test_annotation_set_name_and_description_are_saved(
+    tmp_path: Path,
+    annotation_set: data.AnnotationSet,
+):
+    annotation_set = annotation_set.model_copy(
+        update=dict(
+            name="test_name",
+            description="test description",
+        )
+    )
+
+    # Save the annotation set to a file
+    file_path = tmp_path / "test_aoef_annotation_set.json"
+    io.save(annotation_set, file_path)
+
+    # Load the annotation set from the file
+    loaded_annotation_set = io.load(file_path)
+    assert isinstance(loaded_annotation_set, data.AnnotationSet)
+    assert loaded_annotation_set.name == "test_name"
+    assert loaded_annotation_set.description == "test description"

--- a/tests/test_io/test_aoef/test_prediction_set.py
+++ b/tests/test_io/test_aoef/test_prediction_set.py
@@ -1,6 +1,8 @@
 """Test suite for AOEF Prediction Set Adapter."""
 
-from soundevent import data
+from pathlib import Path
+
+from soundevent import data, io
 from soundevent.io.aoef.prediction_set import (
     PredictionSetAdapter,
     PredictionSetObject,
@@ -24,3 +26,26 @@ def test_prediction_set_is_recovered(
     aoef = prediction_set_adapter.to_aoef(prediction_set)
     recovered = prediction_set_adapter.to_soundevent(aoef)
     assert prediction_set == recovered
+
+
+def test_prediction_set_name_and_description_are_saved(
+    tmp_path: Path,
+    prediction_set: data.PredictionSet,
+):
+    """Test that the name and description of a prediction set are saved."""
+    prediction_set = prediction_set.model_copy(
+        update=dict(
+            name="test_name",
+            description="test description",
+        )
+    )
+
+    # Save the prediction set to a file
+    file_path = tmp_path / "test_aoef_prediction_set.json"
+    io.save(prediction_set, file_path)
+
+    # Load the prediction set from the file
+    loaded_prediction_set = io.load(file_path)
+    assert isinstance(loaded_prediction_set, data.PredictionSet)
+    assert loaded_prediction_set.name == "test_name"
+    assert loaded_prediction_set.description == "test description"

--- a/uv.lock
+++ b/uv.lock
@@ -2405,7 +2405,7 @@ wheels = [
 
 [[package]]
 name = "soundevent"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "email-validator" },


### PR DESCRIPTION
This PR addresses a regression introduced in PR #20, which moved the `name` and `description` fields from the child classes (`AnnotationProject`, `EvaluationSet`, and `ModelRun`) up to their respective base classes (`AnnotationSet` and `PredictionSet`). The goal of that change was to support more flexible groupings of annotations and predictions without enforcing project- or evaluation-specific semantics.

While the change was functionally correct and backwards compatible at runtime, it inadvertently broke serialization. Specifically, the new `name` and `description` fields were **not being persisted** when saving these objects via the `soundevent.io.save` function, because the corresponding serialization logic was not updated to account for the new fields.

### Fixes in This PR

- Updated the serialization logic to correctly handle `name` and `description` fields in `AnnotationSet` and `PredictionSet`.
- Added unit tests that explicitly check that these fields are correctly saved and restored.
- Verified that the fix is backwards compatible and doesn’t affect the loading of previously serialized data.