### PR TITLE
Feat: Add `scale` and `sort_dims` arguments to `compute_spectrogram`

### DIFF
--- a/src/soundevent/audio/spectrograms.py
+++ b/src/soundevent/audio/spectrograms.py
@@ -18,6 +18,8 @@ __all__ = [
     "compute_spectrogram",
 ]
 
+DEFAULT_DIM_ORDER = ("frequency", "time", "channel")
+
 
 def compute_spectrogram(
     audio: xr.DataArray,
@@ -27,6 +29,8 @@ def compute_spectrogram(
     detrend: Union[str, Callable, Literal[False]] = False,
     padded: bool = True,
     boundary: Optional[Literal["zeros", "odd", "even", "constant"]] = "zeros",
+    scale: Literal["amplitude", "power", "psd"] = "psd",
+    sort_dims: Union[tuple[str, ...], bool] = DEFAULT_DIM_ORDER,
 ) -> xr.DataArray:
     """Compute the spectrogram of a signal.
 
@@ -60,6 +64,28 @@ def compute_spectrogram(
         the STFT. See
         [`scipy.signal.stft`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.stft.html).
         Default is "zeros".
+    scale: Literal["amplitude", "power", "psd"], optional
+        Specifies the scaling of the returned spectrogram values.
+        Default is "psd".
+        - "amplitude": Returns the magnitude of the STFT components.
+          Units are typically the same as the input signal (e.g., V).
+        - "power": Returns the squared magnitude of the STFT components.
+          Units are the square of the input signal's units (e.g., V**2).
+          This corresponds to the energy in each time-frequency bin,
+          normalized for windowing effects but not frequency bin width.
+        - "psd": Returns the Power Spectral Density. Units include per
+          Hertz (e.g., V**2/Hz). This scaling accounts for windowing
+          effects and frequency bin width, representing power density.
+    sort_dims: Union[tuple[str, ...], bool], optional
+        Controls the final dimension order of the output DataArray.
+        - If `True`, transpose to `DEFAULT_DIM_ORDER`
+          (currently ("frequency", "time", "channel")).
+        - If a tuple of dimension names (e.g., ("channel", "frequency", "time")),
+          transpose to that specific order. `missing_dims="ignore"` is used.
+        - If `False`, do not transpose; return the array with the dimension
+          order directly resulting from the STFT calculation (see Notes).
+        Default is `DEFAULT_DIM_ORDER`.
+
 
     Returns
     -------
@@ -73,6 +99,26 @@ def compute_spectrogram(
     *  The time axis of the spectrogram represents the center of each STFT window.
     *  The first time bin is centered at time t=hop_size / 2.
     *  Subsequent time bins are spaced by hop_size.
+
+    **Scaling Implementation:**
+    * The different `scale` options leverage `scipy.signal.stft`'s `scaling`
+        parameter and post-processing:
+        - `scale="amplitude"` uses `stft(scaling='spectrum')` and computes `np.abs()`.
+        - `scale="power"` uses `stft(scaling='spectrum')` and computes `np.abs()**2`.
+        - `scale="psd"` uses `stft(scaling='psd')` and computes `np.abs()**2`.
+    * Units mentioned in the `scale` parameter description assume the input
+        signal `audio` has units of Volts (V) for illustrative purposes.
+
+    **Dimension Ordering:**
+    * The intermediate dimension order, before applying `sort_dims` (i.e.,
+        the order if `sort_dims=False`), follows the structure where the
+        original time dimension (`axis`) is replaced by the frequency dimension,
+        and the new time segment dimension is appended last. For example, an
+        input with dims `("height", "time", "channel")` results in an
+        intermediate order of `("height", "frequency", "channel", "time")`.
+    * By default (`sort_dims=True`), the output is transposed to match
+        `DEFAULT_DIM_ORDER`, which is `("frequency", "time", "channel")`.
+
     """
     samplerate = 1 / get_dim_step(audio, Dimensions.time.value)
     time_axis: int = audio.get_axis_num(Dimensions.time.value)  # type: ignore
@@ -91,15 +137,42 @@ def compute_spectrogram(
         detrend=detrend,  # type: ignore
         padded=padded,
         boundary=boundary,  # type: ignore
-        scaling="psd",
+        scaling="psd" if scale == "psd" else "spectrum",
     )
 
-    # Compute the power spectral density
-    psd = np.abs(spectrogram) ** 2
+    original_units = audio.attrs.get(ArrayAttrs.units.value, "V")
+    if scale == "psd":
+        # Compute the power spectral density
+        spectrogram = np.abs(spectrogram) ** 2
+        long_name = "Power Spectral Density Spectrogram"
+        units = f"{original_units}**2/Hz"
+    elif scale == "amplitude":
+        spectrogram = np.abs(spectrogram)
+        long_name = "Amplitude Spectrogram"
+        units = f"{original_units}"
+    elif scale == "power":
+        spectrogram = np.abs(spectrogram) ** 2
+        long_name = "Power Spectrogram"
+        units = f"{original_units}**2"
+    else:
+        raise ValueError(
+            f"Invalid scale option {scale}. Choose one of: "
+            "psd, amplitude, power"
+        )
 
-    return xr.DataArray(
-        data=np.swapaxes(psd, 1, 2),
-        dims=("frequency", "time", "channel"),
+    dims = (
+        *[
+            name
+            if name != Dimensions.time.value
+            else Dimensions.frequency.value
+            for name in audio.dims
+        ],
+        Dimensions.time.value,
+    )
+
+    array = xr.DataArray(
+        data=spectrogram,
+        dims=dims,
         coords={
             Dimensions.frequency.value: create_frequency_dim_from_array(
                 frequencies,
@@ -116,8 +189,16 @@ def compute_spectrogram(
             "window_size": window_size,
             "hop_size": hop_size,
             "window_type": window_type,
-            ArrayAttrs.units.value: "V**2/Hz",
+            ArrayAttrs.units.value: units,
             ArrayAttrs.standard_name.value: "spectrogram",
-            ArrayAttrs.long_name.value: "Power Spectral Density",
+            ArrayAttrs.long_name.value: long_name,
         },
     )
+
+    if sort_dims:
+        if not isinstance(sort_dims, tuple):
+            sort_dims = DEFAULT_DIM_ORDER
+
+        return array.transpose(..., *sort_dims, missing_dims="ignore")
+
+    return array

--- a/tests/test_audio/test_spectrograms.py
+++ b/tests/test_audio/test_spectrograms.py
@@ -1,9 +1,19 @@
 """Test suite for spectrograms functions."""
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from soundevent import arrays, audio, data
+from soundevent.audio.spectrograms import compute_spectrogram
+
+
+@pytest.fixture
+def sample_wave(random_wav):
+    samplerate = 16000
+    path = random_wav(samplerate=samplerate, duration=1)
+    recording = data.Recording.from_file(path)
+    return audio.load_recording(recording)
 
 
 def test_compute_spectrograms_from_recordings(random_wav):
@@ -126,3 +136,116 @@ def test_spectrogram_has_correct_frequency_step(random_wav):
     step = arrays.estimate_dim_step(spectrogram.frequency)
     assert step == samplerate / 1024
     assert spectrogram.frequency.attrs["step"] == samplerate / 1024
+
+
+def test_can_compute_spectrogram_of_transposed_audio(random_wav):
+    samplerate = 16000
+    nfft = 1024
+    window_size = nfft / samplerate
+    hop_size = 512 / samplerate
+
+    path = random_wav(samplerate=samplerate, duration=0.2)
+    recording = data.Recording.from_file(path)
+    clip = data.Clip(recording=recording, start_time=0.1, end_time=0.9)
+    waveform = audio.load_clip(clip).T
+
+    spectrogram = compute_spectrogram(
+        waveform,
+        window_size,
+        hop_size,
+        sort_dims=False,
+    )
+    assert spectrogram.ndim == 3
+    assert spectrogram.dims == ("channel", "frequency", "time")
+
+
+def test_spectrogram_dim_order():
+    samplerate = 16_000
+    nfft = 1024
+    win_size = nfft / samplerate
+    hop_size = 512 / samplerate
+    times = np.linspace(0, 1, 16000)
+    channels = np.array([0, 1])
+    heights = np.arange(10)
+
+    wave = xr.DataArray(
+        np.random.random([len(heights), len(times), len(channels)]),
+        dims=("height", "time", "channel"),
+        coords={"height": heights, "time": times, "channel": channels},
+    )
+
+    spec = compute_spectrogram(wave, win_size, hop_size, sort_dims=False)
+    assert spec.dims == ("height", "frequency", "channel", "time")
+
+    wave = wave.transpose("height", "channel", "time")
+    spec = compute_spectrogram(wave, win_size, hop_size, sort_dims=False)
+    assert spec.dims == ("height", "channel", "frequency", "time")
+
+    wave = wave.transpose("time", "channel", "height")
+    spec = compute_spectrogram(wave, win_size, hop_size, sort_dims=False)
+    assert spec.dims == ("frequency", "channel", "height", "time")
+
+
+def test_can_compute_spectrogram_of_audio_without_channel_dim(random_wav):
+    samplerate = 16000
+    nfft = 1024
+    window_size = nfft / samplerate
+    hop_size = 512 / samplerate
+
+    path = random_wav(samplerate=samplerate, duration=0.2)
+    recording = data.Recording.from_file(path)
+    clip = data.Clip(recording=recording, start_time=0.1, end_time=0.9)
+    waveform = audio.load_clip(clip)
+    waveform = waveform.sel(channel=0)
+
+    spectrogram = compute_spectrogram(waveform, window_size, hop_size)
+    assert spectrogram.ndim == 2
+    assert spectrogram.dims == ("frequency", "time")
+
+
+def test_can_compute_amplitude_spectrogram(sample_wave):
+    samplerate = 16000
+    nfft = 1024
+    window_size = nfft / samplerate
+    hop_size = 512 / samplerate
+    spectrogram = compute_spectrogram(
+        sample_wave,
+        window_size,
+        hop_size,
+        scale="amplitude",
+    )
+
+    assert spectrogram.attrs["units"] == "V"
+    assert spectrogram.attrs["long_name"] == "Amplitude Spectrogram"
+
+
+def test_can_compute_power_spectrogram(sample_wave):
+    samplerate = 16000
+    nfft = 1024
+    window_size = nfft / samplerate
+    hop_size = 512 / samplerate
+    spectrogram = compute_spectrogram(
+        sample_wave,
+        window_size,
+        hop_size,
+        scale="power",
+    )
+
+    assert spectrogram.attrs["units"] == "V**2"
+    assert spectrogram.attrs["long_name"] == "Power Spectrogram"
+
+
+def test_can_compute_psd_spectrogram(sample_wave):
+    samplerate = 16000
+    nfft = 1024
+    window_size = nfft / samplerate
+    hop_size = 512 / samplerate
+    spectrogram = compute_spectrogram(
+        sample_wave,
+        window_size,
+        hop_size,
+        scale="psd",
+    )
+
+    assert spectrogram.attrs["units"] == "V**2/Hz"
+    assert spectrogram.attrs["long_name"] == "Power Spectral Density Spectrogram"

--- a/uv.lock
+++ b/uv.lock
@@ -2405,7 +2405,7 @@ wheels = [
 
 [[package]]
 name = "soundevent"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "email-validator" },


### PR DESCRIPTION
This PR refines the `soundevent.audio.spectrograms.compute_spectrogram` function by introducing two new arguments: `scale` and `sort_dims`.

## Added `scale` Argument

Previously, the function exclusively returned Power Spectral Density (PSD) spectrograms. To support other use cases, this PR adds the ability to compute amplitude and power spectrograms directly.

A new scale argument allows specifying the desired output:

- "psd": Power Spectral Density (Units: `V**2/Hz`)
- "power": Power Spectrogram (Units: `V**2`)
- "amplitude": Amplitude Spectrogram (Units: `V`)

The default value remains "psd", ensuring no breaking changes to existing usage.

## Added `sort_dims` Argument

Previously, the function broke when handling input xr.DataArrays that deviated from a simple (time, channel) structure, causing issues with 1D audio, arrays having dimensions beyond time and channel, or inputs where the time axis was positioned differently. Furthermore, the output spectrogram dimensions were always transposed to the fixed order ("frequency", "time", "channel"). This mandatory transposition isn't always necessary or desired for subsequent processing steps and introduces computational overhead by potentially rearranging data unnecessarily.

A new sort_dims argument provides control over the output dimension order:

- `True` (Default): Transposes the output dimensions to match DEFAULT_DIM_ORDER (currently ("frequency", "time", "channel")), maintaining previous default behavior.
- `tuple[str, ...]`: Transposes the output dimensions to the specified order (e.g., ("channel", "frequency", "time")).
- `False`: Skips the final transpose step, returning the spectrogram with the dimension order naturally resulting from the scipy.signal.stft calculation (where the new time axis is last, and the frequency axis replaces the original time axis relative to other dimensions). This avoids unnecessary data manipulation if the default order is not required.

Both additions are documented and include corresponding unit tests.