### PR TITLE
Fix/plot prediction tags with transparency

### DIFF
--- a/src/soundevent/plot/annotation.py
+++ b/src/soundevent/plot/annotation.py
@@ -26,7 +26,38 @@ def plot_annotation(
     color: Optional[str] = None,
     **kwargs,
 ) -> Axes:
-    """Plot an annotation."""
+    """Plot a sound event annotation on a spectrogram.
+
+    This function plots the geometry of the sound event and its associated
+    tags.
+
+    Parameters
+    ----------
+    annotation
+        The sound event annotation to plot.
+    ax
+        The matplotlib axes to plot on. If None, a new one is created.
+    position
+        The position of the tags relative to the geometry.
+    color_mapper
+        A `TagColorMapper` instance to map tags to colors. If None, a new
+        one is created.
+    time_offset
+        The time offset for positioning the tags.
+    freq_offset
+        The frequency offset for positioning the tags.
+    color
+        The color of the geometry. If None, the color is determined by the
+        color mapper.
+    **kwargs
+        Additional keyword arguments passed to `create_axes` and
+        `plot_geometry`.
+
+    Returns
+    -------
+    Axes
+        The matplotlib axes with the annotation plotted.
+    """
     geometry = annotation.sound_event.geometry
 
     if geometry is None:
@@ -66,7 +97,39 @@ def plot_annotations(
     color: Optional[str] = None,
     **kwargs,
 ):
-    """Plot an annotation."""
+    """Plot a collection of sound event annotations on a spectrogram.
+
+    This function iterates through a collection of sound event annotations
+    and plots each one on the provided matplotlib axes.
+
+    Parameters
+    ----------
+    annotations
+        An iterable of `SoundEventAnnotation` objects to plot.
+    ax
+        The matplotlib axes to plot on. If None, a new one is created.
+    position
+        The position of the tags relative to the geometry.
+    color_mapper
+        A `TagColorMapper` instance to map tags to colors. If None, a new
+        one is created.
+    time_offset
+        The time offset for positioning the tags.
+    freq_offset
+        The frequency offset for positioning the tags.
+    legend
+        Whether to add a legend for the tags.
+    color
+        The color of the geometries. If None, the color is determined by
+        the color mapper.
+    **kwargs
+        Additional keyword arguments passed to `plot_annotation`.
+
+    Returns
+    -------
+    Axes
+        The matplotlib axes with the annotations plotted.
+    """
     if ax is None:
         ax = create_axes(**kwargs)
 

--- a/src/soundevent/plot/prediction.py
+++ b/src/soundevent/plot/prediction.py
@@ -25,7 +25,43 @@ def plot_prediction(
     color: Optional[str] = None,
     **kwargs,
 ) -> Axes:
-    """Plot an annotation."""
+    """Plot a sound event prediction on a spectrogram.
+
+    This function plots the geometry of the sound event and its associated
+    tags. The transparency of the geometry is determined by the prediction
+    score and the `max_alpha` parameter. The transparency of the tags is
+    directly controlled by the prediction score of each tag.
+
+    Parameters
+    ----------
+    prediction
+        The sound event prediction to plot.
+    ax
+        The matplotlib axes to plot on. If None, a new one is created.
+    position
+        The position of the tags relative to the geometry.
+    color_mapper
+        A `TagColorMapper` instance to map tags to colors. If None, a new
+        one is created.
+    time_offset
+        The time offset for positioning the tags.
+    freq_offset
+        The frequency offset for positioning the tags.
+    max_alpha
+        The maximum transparency of the plotted geometry, scaled by the
+        prediction score.
+    color
+        The color of the geometry. If None, the color is determined by the
+        color mapper.
+    **kwargs
+        Additional keyword arguments passed to `create_axes` and
+        `plot_geometry`.
+
+    Returns
+    -------
+    Axes
+        The matplotlib axes with the prediction plotted.
+    """
     geometry = prediction.sound_event.geometry
 
     if geometry is None:
@@ -73,7 +109,42 @@ def plot_predictions(
     color: Optional[str] = None,
     **kwargs,
 ):
-    """Plot an prediction."""
+    """Plot a collection of sound event predictions on a spectrogram.
+
+    This function iterates through a collection of sound event predictions
+    and plots each one on the provided matplotlib axes.
+
+    Parameters
+    ----------
+    predictions
+        An iterable of `SoundEventPrediction` objects to plot.
+    ax
+        The matplotlib axes to plot on. If None, a new one is created.
+    position
+        The position of the tags relative to the geometry.
+    color_mapper
+        A `TagColorMapper` instance to map tags to colors. If None, a new
+        one is created.
+    time_offset
+        The time offset for positioning the tags.
+    freq_offset
+        The frequency offset for positioning the tags.
+    legend
+        Whether to add a legend for the tags.
+    max_alpha
+        The maximum transparency of the plotted geometries, scaled by the
+        prediction score.
+    color
+        The color of the geometries. If None, the color is determined by
+        the color mapper.
+    **kwargs
+        Additional keyword arguments passed to `plot_prediction`.
+
+    Returns
+    -------
+    Axes
+        The matplotlib axes with the predictions plotted.
+    """
     if ax is None:
         ax = create_axes(**kwargs)
 

--- a/src/soundevent/plot/tags.py
+++ b/src/soundevent/plot/tags.py
@@ -47,9 +47,33 @@ def plot_tag(
     color: str,
     ax: Optional[Axes] = None,
     size: int = 10,
+    alpha: float = 1,
     **kwargs,
 ) -> Axes:
-    """Plot a tag."""
+    """Plot a tag as a dot on a spectrogram.
+
+    Parameters
+    ----------
+    time
+        Time coordinate of the tag.
+    frequency
+        Frequency coordinate of the tag.
+    color
+        Color of the tag.
+    ax
+        Axes to plot on. If None, a new one is created.
+    size
+        Size of the tag marker.
+    alpha
+        Transparency of the tag marker.
+    **kwargs
+        Keyword arguments passed to `create_axes`.
+
+    Returns
+    -------
+    Axes
+        Axes with the tag plotted.
+    """
     if ax is None:
         ax = create_axes(**kwargs)
 
@@ -59,6 +83,7 @@ def plot_tag(
         marker="o",
         color=color,
         s=size,
+        alpha=alpha,
     )
 
     return ax


### PR DESCRIPTION
This PR addresses an issue where the transparency of predicted sound event tags was not being correctly handled. The `alpha` argument in the `plot_tag` function was not being used, causing all tags to be plotted with full opacity.

Changes:
- The `plot_tag` function now correctly applies the `alpha` parameter to control the transparency of the plotted tags.
- The docstrings for `plot_tag`, `plot_prediction`, `plot_predictions`, `plot_annotation`, and `plot_annotations` have been updated to reflect the changes and provide more detailed information about the functions' behavior.