### PR TITLE
Perf: Optimize compute_bounds for simple geometries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ docs/generated/
 .virtual_documents
 
 **.ipynb
+
+GEMINI.md

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -59,19 +59,19 @@ def compute_bounds(
         The bounds of the geometry. The bounds are returned in the
         following order: start_time, low_freq, end_time, high_freq.
     """
-    if isinstance(geometry, data.TimeStamp):
+    if geometry.type == "TimeStamp":
         time = geometry.coordinates
         return time, 0, time, data.MAX_FREQUENCY
 
-    if isinstance(geometry, data.TimeInterval):
+    if geometry.type == "TimeInterval":
         start_time, end_time = geometry.coordinates
         return start_time, 0, end_time, data.MAX_FREQUENCY
 
-    if isinstance(geometry, data.BoundingBox):
+    if geometry.type == "BoundingBox":
         start_time, low_freq, end_time, high_freq = geometry.coordinates
         return start_time, low_freq, end_time, high_freq
 
-    if isinstance(geometry, data.Point):
+    if geometry.type == "Point":
         time, frequency = geometry.coordinates
         return time, frequency, time, frequency
 

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -59,6 +59,22 @@ def compute_bounds(
         The bounds of the geometry. The bounds are returned in the
         following order: start_time, low_freq, end_time, high_freq.
     """
+    if isinstance(geometry, data.TimeStamp):
+        time = geometry.coordinates
+        return time, 0, time, data.MAX_FREQUENCY
+
+    if isinstance(geometry, data.TimeInterval):
+        start_time, end_time = geometry.coordinates
+        return start_time, 0, end_time, data.MAX_FREQUENCY
+
+    if isinstance(geometry, data.BoundingBox):
+        start_time, low_freq, end_time, high_freq = geometry.coordinates
+        return start_time, low_freq, end_time, high_freq
+
+    if isinstance(geometry, data.Point):
+        time, frequency = geometry.coordinates
+        return time, frequency, time, frequency
+
     shp_geom = geometry_to_shapely(geometry)
     return shp_geom.bounds
 


### PR DESCRIPTION
This pull request optimizes the `compute_bounds` function by avoiding the conversion to a shapely geometry for simple cases like `TimeStamp`, `TimeInterval`, `BoundingBox`, and `Point`. This results in a significant performance improvement for these common geometry types.

For these simple geometries, the bounds can be directly computed from their coordinates without the need for the more complex operations involved in converting to a shapely geometry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved bounds calculation for timestamps, time intervals, bounding boxes, and points to return precise extents, avoiding unnecessary conversions and improving consistency for visualization, selection, and filtering.
- Chores
  - Updated ignore rules to exclude additional project documentation from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->