### PR TITLE
feat: Implement interval overlap functions

### DIFF
--- a/src/soundevent/geometry/__init__.py
+++ b/src/soundevent/geometry/__init__.py
@@ -19,6 +19,7 @@ from soundevent.geometry.html import geometry_to_html
 from soundevent.geometry.operations import (
     buffer_geometry,
     compute_bounds,
+    compute_interval_overlap,
     get_geometry_point,
     group_sound_events,
     have_frequency_overlap,
@@ -31,6 +32,7 @@ __all__ = [
     "buffer_geometry",
     "compute_bounds",
     "compute_geometric_features",
+    "compute_interval_overlap",
     "geometry_to_html",
     "geometry_to_shapely",
     "get_geometry_point",

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -585,7 +585,7 @@ def compute_interval_overlap(
     start2, stop2 = interval2
     start = max(start1, start2)
     stop = min(stop1, stop2)
-    return max(stop - start, 0)
+    return float(max(stop - start, 0))
 
 
 def intervals_overlap(

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -647,10 +647,6 @@ def intervals_overlap(
 
         width1 = interval1[1] - interval1[0]
         width2 = interval2[1] - interval2[0]
-
-        if width1 == 0 or width2 == 0:
-            return False
-
         min_width = min(width1, width2)
         required_overlap = min_relative_overlap * min_width
         return overlap > required_overlap

--- a/tests/test_geometry/test_operations.py
+++ b/tests/test_geometry/test_operations.py
@@ -430,6 +430,13 @@ def test_compute_interval_overlap():
     assert compute_interval_overlap((0, 0), (0, 0)) == 0
     assert compute_interval_overlap((0, 0), (1, 1)) == 0
 
+    # Raises error if intervals are invalid
+    with pytest.raises(ValueError):
+        compute_interval_overlap((1, 0), (0, 1))
+
+    with pytest.raises(ValueError):
+        compute_interval_overlap((0, 1), (1, 0))
+
 
 def test_intervals_overlap():
     """Test the intervals_overlap function."""

--- a/tests/test_geometry/test_operations.py
+++ b/tests/test_geometry/test_operations.py
@@ -12,10 +12,12 @@ from soundevent.data.geometries import BaseGeometry
 from soundevent.geometry.operations import (
     buffer_geometry,
     compute_bounds,
+    compute_interval_overlap,
     get_geometry_point,
     group_sound_events,
     have_frequency_overlap,
     have_temporal_overlap,
+    intervals_overlap,
     is_in_clip,
     rasterize,
 )
@@ -401,6 +403,68 @@ def test_is_in_clip_invalid_input(recording: data.Recording):
     clip = data.Clip(start_time=0.0, end_time=5.0, recording=recording)
     with pytest.raises(ValueError):
         is_in_clip(geometry, clip, minimum_overlap=-1.0)
+
+
+def test_compute_interval_overlap():
+    """Test the computation of overlap between two intervals."""
+    # No overlap
+    assert compute_interval_overlap((0, 1), (2, 3)) == 0
+    assert compute_interval_overlap((2, 3), (0, 1)) == 0
+
+    # Partial overlap
+    assert compute_interval_overlap((0, 2), (1, 3)) == 1
+    assert compute_interval_overlap((1, 3), (0, 2)) == 1
+
+    # Full overlap
+    assert compute_interval_overlap((0, 4), (1, 3)) == 2
+    assert compute_interval_overlap((1, 3), (0, 4)) == 2
+
+    # Touching intervals
+    assert compute_interval_overlap((0, 1), (1, 2)) == 0
+    assert compute_interval_overlap((1, 2), (0, 1)) == 0
+
+    # Identical intervals
+    assert compute_interval_overlap((0, 1), (0, 1)) == 1
+
+    # Zero-length intervals
+    assert compute_interval_overlap((0, 0), (0, 0)) == 0
+    assert compute_interval_overlap((0, 0), (1, 1)) == 0
+
+
+def test_intervals_overlap():
+    """Test the intervals_overlap function."""
+    # No overlap
+    assert not intervals_overlap((0, 1), (2, 3))
+
+    # Partial overlap
+    assert intervals_overlap((0, 2), (1, 3))
+
+    # Full overlap
+    assert intervals_overlap((0, 4), (1, 3))
+
+    # Touching intervals
+    assert not intervals_overlap((0, 1), (1, 2))
+
+    # Identical intervals
+    assert intervals_overlap((0, 1), (0, 1))
+
+    # Absolute overlap
+    assert intervals_overlap((0, 2), (1, 3), min_absolute_overlap=0.5)
+    assert not intervals_overlap((0, 2), (1, 3), min_absolute_overlap=1.5)
+
+    # Relative overlap
+    assert intervals_overlap((0, 2), (1, 3), min_relative_overlap=0.25)
+    assert not intervals_overlap((0, 2), (1, 3), min_relative_overlap=0.75)
+
+    # Invalid input
+    with pytest.raises(ValueError):
+        intervals_overlap(
+            (0, 2), (1, 3), min_absolute_overlap=1, min_relative_overlap=0.5
+        )
+    with pytest.raises(ValueError):
+        intervals_overlap((0, 2), (1, 3), min_relative_overlap=-0.5)
+    with pytest.raises(ValueError):
+        intervals_overlap((0, 2), (1, 3), min_relative_overlap=1.5)
 
 
 def test_have_temporal_overlap_full_overlap():


### PR DESCRIPTION
This PR introduces the `compute_interval_overlap` function and refactors the existing `intervals_overlap` function to use it.

- `compute_interval_overlap`: a new function to compute the length of the overlap between two intervals.
- `intervals_overlap`: refactored to use the new `compute_interval_overlap` function and improve the logic for checking overlap with absolute and relative thresholds.

This PR also includes:
- Unit tests for the new and refactored functions.
- Updated docstrings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a utility to compute the length of overlap between two intervals, now exposed in the geometry package.
- Refactor
  - Overlap evaluation now requires strictly positive overlap by default (touching intervals no longer count).
  - Default overlap parameters for temporal and frequency checks adjusted to align with strict semantics.
- Documentation
  - Clarified strict-overlap behavior and relative-overlap calculation using the shorter interval.
- Tests
  - Added tests for overlap lengths, boolean overlap with absolute/relative thresholds, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->