### PR TITLE
feat: Add shift and scale operations for geometries

### DIFF
--- a/src/soundevent/geometry/__init__.py
+++ b/src/soundevent/geometry/__init__.py
@@ -13,7 +13,10 @@ truths for evaluation. The geometry module simplifies these tasks by providing
 a clear and efficient interface for handling sound event geometries.
 """
 
-from soundevent.geometry.conversion import geometry_to_shapely
+from soundevent.geometry.conversion import (
+    geometry_to_shapely,
+    shapely_to_geometry,
+)
 from soundevent.geometry.features import compute_geometric_features
 from soundevent.geometry.html import geometry_to_html
 from soundevent.geometry.operations import (
@@ -26,6 +29,8 @@ from soundevent.geometry.operations import (
     intervals_overlap,
     is_in_clip,
     rasterize,
+    scale_geometry,
+    shift_geometry,
 )
 
 __all__ = [
@@ -42,4 +47,7 @@ __all__ = [
     "intervals_overlap",
     "is_in_clip",
     "rasterize",
+    "scale_geometry",
+    "shapely_to_geometry",
+    "shift_geometry",
 ]

--- a/src/soundevent/geometry/conversion.py
+++ b/src/soundevent/geometry/conversion.py
@@ -1,6 +1,6 @@
 """Convert Geometry objects into shapely objects and vice versa."""
 
-from typing import overload
+from typing import List, overload
 
 import shapely
 from shapely import geometry
@@ -9,6 +9,7 @@ from soundevent import data
 
 __all__ = [
     "geometry_to_shapely",
+    "shapely_to_geometry",
 ]
 
 
@@ -274,3 +275,49 @@ def geometry_to_shapely(
         return multipolygon_to_shapely(geom)
 
     raise NotImplementedError(f"Unknown geometry type: {geom.type}")
+
+
+def _shapely_polygon_to_coords(
+    geom: shapely.Polygon,
+) -> List[List[List[float]]]:
+    shell = [[point[0], point[1]] for point in geom.exterior.coords]
+    holes = [
+        [[point[0], point[1]] for point in interior.coords]
+        for interior in geom.interiors
+    ]
+    return [shell, *holes]
+
+
+def shapely_to_geometry(geom: shapely.Geometry) -> data.Geometry:
+    if isinstance(geom, shapely.Point):
+        return data.Point(coordinates=[geom.x, geom.y])
+
+    if isinstance(geom, shapely.MultiPoint):
+        return data.MultiPoint(
+            coordinates=[[point.x, point.y] for point in geom.geoms]
+        )
+
+    if isinstance(geom, shapely.LineString):
+        return data.LineString(
+            coordinates=[[point[0], point[1]] for point in geom.coords]
+        )
+
+    if isinstance(geom, shapely.MultiLineString):
+        return data.MultiLineString(
+            coordinates=[
+                [[point[0], point[1]] for point in linestring.coords]
+                for linestring in geom.geoms
+            ]
+        )
+
+    if isinstance(geom, shapely.Polygon):
+        return data.Polygon(coordinates=_shapely_polygon_to_coords(geom))
+
+    if isinstance(geom, shapely.MultiPolygon):
+        return data.MultiPolygon(
+            coordinates=[
+                _shapely_polygon_to_coords(poly) for poly in geom.geoms
+            ]
+        )
+
+    raise NotImplementedError("Unknown geometry")

--- a/src/soundevent/geometry/conversion.py
+++ b/src/soundevent/geometry/conversion.py
@@ -289,6 +289,23 @@ def _shapely_polygon_to_coords(
 
 
 def shapely_to_geometry(geom: shapely.Geometry) -> data.Geometry:
+    """Convert a shapely geometry to a soundevent geometry.
+
+    Parameters
+    ----------
+    geom
+        The shapely geometry to convert.
+
+    Returns
+    -------
+    data.Geometry
+        The converted soundevent geometry.
+
+    Raises
+    ------
+    NotImplementedError
+        If the geometry type is not supported.
+    """
     if isinstance(geom, shapely.Point):
         return data.Point(coordinates=[geom.x, geom.y])
 

--- a/src/soundevent/geometry/conversion.py
+++ b/src/soundevent/geometry/conversion.py
@@ -306,20 +306,20 @@ def shapely_to_geometry(geom: shapely.Geometry) -> data.Geometry:
     NotImplementedError
         If the geometry type is not supported.
     """
-    if isinstance(geom, shapely.Point):
+    if isinstance(geom, geometry.Point):
         return data.Point(coordinates=[geom.x, geom.y])
 
-    if isinstance(geom, shapely.MultiPoint):
+    if isinstance(geom, geometry.MultiPoint):
         return data.MultiPoint(
             coordinates=[[point.x, point.y] for point in geom.geoms]
         )
 
-    if isinstance(geom, shapely.LineString):
+    if isinstance(geom, geometry.LineString):
         return data.LineString(
             coordinates=[[point[0], point[1]] for point in geom.coords]
         )
 
-    if isinstance(geom, shapely.MultiLineString):
+    if isinstance(geom, geometry.MultiLineString):
         return data.MultiLineString(
             coordinates=[
                 [[point[0], point[1]] for point in linestring.coords]
@@ -327,10 +327,10 @@ def shapely_to_geometry(geom: shapely.Geometry) -> data.Geometry:
             ]
         )
 
-    if isinstance(geom, shapely.Polygon):
+    if isinstance(geom, geometry.Polygon):
         return data.Polygon(coordinates=_shapely_polygon_to_coords(geom))
 
-    if isinstance(geom, shapely.MultiPolygon):
+    if isinstance(geom, geometry.MultiPolygon):
         return data.MultiPolygon(
             coordinates=[
                 _shapely_polygon_to_coords(poly) for poly in geom.geoms

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -1,6 +1,5 @@
 """Functions that handle SoundEvent geometries."""
 
-import json
 from collections import defaultdict
 from itertools import combinations
 from typing import (
@@ -28,7 +27,10 @@ from soundevent.arrays import (
     get_coord_index,
 )
 from soundevent.data import Geometry
-from soundevent.geometry.conversion import geometry_to_shapely
+from soundevent.geometry.conversion import (
+    geometry_to_shapely,
+    shapely_to_geometry,
+)
 
 __all__ = [
     "buffer_geometry",
@@ -266,10 +268,7 @@ def buffer_shapely_geometry(
         max_time + 1,
         data.MAX_FREQUENCY,
     )
-    json_data = json.loads(shapely.to_geojson(buffered))
-    if json_data["type"] == "Polygon":
-        return data.Polygon(coordinates=json_data["coordinates"])
-    return data.MultiPolygon(coordinates=json_data["coordinates"])
+    return shapely_to_geometry(buffered)
 
 
 Value = Union[float, int]
@@ -861,4 +860,204 @@ def _compute_similarity_matrix(
         (values, (col, row)),
         shape=(rows, rows),
         dtype=np.int8,
+    )
+
+
+def _shift_time_stamp(geom: data.TimeStamp, time: float = 0) -> data.TimeStamp:
+    geom_time = geom.coordinates
+    return data.TimeStamp(coordinates=geom_time + time)
+
+
+def _shift_time_interval(
+    geom: data.TimeInterval, time: float = 0
+) -> data.TimeInterval:
+    start_time, end_time = geom.coordinates
+    return data.TimeInterval(coordinates=[start_time + time, end_time + time])
+
+
+def _shift_bounding_box(
+    geom: data.BoundingBox,
+    time: float = 0,
+    freq: float = 0,
+) -> data.BoundingBox:
+    start_time, low_freq, end_time, high_freq = geom.coordinates
+    return data.BoundingBox(
+        coordinates=[
+            start_time + time,
+            low_freq + freq,
+            end_time + time,
+            high_freq + freq,
+        ]
+    )
+
+
+def _shift_point(
+    geom: data.Point,
+    time: float = 0,
+    freq: float = 0,
+) -> data.Point:
+    geom_time, geom_freq = geom.coordinates
+    return data.Point(coordinates=[geom_time + time, geom_freq + freq])
+
+
+def _shift_shapely(
+    geom: data.Geometry,
+    time: float = 0,
+    freq: float = 0,
+) -> data.Geometry:
+    shp_geom = geometry_to_shapely(geom)
+    shift = np.array([time, freq])
+    shifted = shapely.transform(
+        shp_geom,
+        lambda coords: coords + shift[None, :],
+    )
+    return shapely_to_geometry(shifted)
+
+
+def shift_geometry(
+    geom: data.Geometry,
+    time: float = 0,
+    freq: float = 0,
+) -> data.Geometry:
+    if geom.type == "Point":
+        return _shift_point(geom, time=time, freq=freq)
+
+    if geom.type == "BoundingBox":
+        return _shift_bounding_box(geom, time=time, freq=freq)
+
+    if geom.type == "TimeInterval":
+        return _shift_time_interval(geom, time=time)
+
+    if geom.type == "TimeStamp":
+        return _shift_time_stamp(geom, time=time)
+
+    return _shift_shapely(geom, time=time, freq=freq)
+
+
+def scale_value(val: float, factor: float = 1, anchor: float = 0):
+    return (val - anchor) * factor + anchor
+
+
+def _scale_time_stamp(
+    geom: data.TimeStamp,
+    time: float = 0,
+    time_anchor: float = 0,
+) -> data.TimeStamp:
+    geom_time = geom.coordinates
+    return data.TimeStamp(
+        coordinates=scale_value(geom_time, time, time_anchor)
+    )
+
+
+def _scale_time_interval(
+    geom: data.TimeInterval,
+    time: float = 0,
+    time_anchor: float = 0,
+) -> data.TimeInterval:
+    start_time, end_time = geom.coordinates
+    return data.TimeInterval(
+        coordinates=[
+            scale_value(start_time, time, time_anchor),
+            scale_value(end_time, time, time_anchor),
+        ]
+    )
+
+
+def _scale_bounding_box(
+    geom: data.BoundingBox,
+    time: float = 0,
+    freq: float = 0,
+    time_anchor: float = 0,
+    freq_anchor: float = 0,
+) -> data.BoundingBox:
+    start_time, low_freq, end_time, high_freq = geom.coordinates
+    return data.BoundingBox(
+        coordinates=[
+            scale_value(start_time, time, time_anchor),
+            scale_value(low_freq, freq, freq_anchor),
+            scale_value(end_time, time, time_anchor),
+            scale_value(high_freq, freq, freq_anchor),
+        ]
+    )
+
+
+def _scale_point(
+    geom: data.Point,
+    time: float = 0,
+    freq: float = 0,
+    time_anchor: float = 1,
+    freq_anchor: float = 1,
+) -> data.Point:
+    geom_time, geom_freq = geom.coordinates
+    return data.Point(
+        coordinates=[
+            scale_value(geom_time, time, time_anchor),
+            scale_value(geom_freq, freq, freq_anchor),
+        ]
+    )
+
+
+def _scale_shapely(
+    geom: data.Geometry,
+    time: float = 1,
+    freq: float = 1,
+    time_anchor: float = 0,
+    freq_anchor: float = 0,
+) -> data.Geometry:
+    shp_geom = geometry_to_shapely(geom)
+    factor = np.array([time, freq])
+    anchor = np.array([time_anchor, freq_anchor])
+
+    def _shift_coords(coords: np.ndarray) -> np.ndarray:
+        return (coords - anchor[None, :]) * factor[None, :] + anchor[None, :]
+
+    scaled = shapely.transform(shp_geom, _shift_coords)
+    return shapely_to_geometry(scaled)
+
+
+def scale_geometry(
+    geom: data.Geometry,
+    time: float = 1,
+    freq: float = 1,
+    time_anchor: float = 0,
+    freq_anchor: float = 0,
+) -> data.Geometry:
+    if geom.type == "Point":
+        return _scale_point(
+            geom,
+            time=time,
+            freq=freq,
+            time_anchor=time_anchor,
+            freq_anchor=freq_anchor,
+        )
+
+    if geom.type == "BoundingBox":
+        return _scale_bounding_box(
+            geom,
+            time=time,
+            freq=freq,
+            time_anchor=time_anchor,
+            freq_anchor=freq_anchor,
+        )
+
+    if geom.type == "TimeInterval":
+        return _scale_time_interval(
+            geom,
+            time=time,
+            time_anchor=time_anchor,
+        )
+
+    if geom.type == "TimeStamp":
+        return _scale_time_stamp(
+            geom,
+            time=time,
+            time_anchor=time_anchor,
+        )
+
+    return _scale_shapely(
+        geom,
+        time=time,
+        freq=freq,
+        time_anchor=time_anchor,
+        freq_anchor=freq_anchor,
     )

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -35,14 +35,16 @@ from soundevent.geometry.conversion import (
 __all__ = [
     "buffer_geometry",
     "compute_bounds",
+    "compute_interval_overlap",
     "get_geometry_point",
     "group_sound_events",
     "have_frequency_overlap",
     "have_temporal_overlap",
-    "compute_interval_overlap",
     "intervals_overlap",
     "is_in_clip",
     "rasterize",
+    "scale_geometry",
+    "shift_geometry",
 ]
 
 
@@ -1038,6 +1040,29 @@ def scale_geometry(
     time_anchor: float = 0,
     freq_anchor: float = 0,
 ) -> data.Geometry:
+    """Scale a geometry by a given time and frequency factor.
+
+    The scaling is performed with respect to an anchor point. The formula
+    for scaling a value `val` is `(val - anchor) * factor + anchor`.
+
+    Parameters
+    ----------
+    geom
+        The geometry to scale.
+    time
+        The time factor to apply to the geometry. Defaults to 1.
+    freq
+        The frequency factor to apply to the geometry. Defaults to 1.
+    time_anchor
+        The time anchor to use for scaling, in seconds. Defaults to 0.
+    freq_anchor
+        The frequency anchor to use for scaling, in Hz. Defaults to 0.
+
+    Returns
+    -------
+    data.Geometry
+        The scaled geometry.
+    """
     if geom.type == "Point":
         return _scale_point(
             geom,

--- a/src/soundevent/geometry/operations.py
+++ b/src/soundevent/geometry/operations.py
@@ -958,7 +958,7 @@ def scale_value(val: float, factor: float = 1, anchor: float = 0):
 
 def _scale_time_stamp(
     geom: data.TimeStamp,
-    time: float = 0,
+    time: float = 1,
     time_anchor: float = 0,
 ) -> data.TimeStamp:
     geom_time = geom.coordinates
@@ -969,7 +969,7 @@ def _scale_time_stamp(
 
 def _scale_time_interval(
     geom: data.TimeInterval,
-    time: float = 0,
+    time: float = 1,
     time_anchor: float = 0,
 ) -> data.TimeInterval:
     start_time, end_time = geom.coordinates
@@ -983,8 +983,8 @@ def _scale_time_interval(
 
 def _scale_bounding_box(
     geom: data.BoundingBox,
-    time: float = 0,
-    freq: float = 0,
+    time: float = 1,
+    freq: float = 1,
     time_anchor: float = 0,
     freq_anchor: float = 0,
 ) -> data.BoundingBox:
@@ -1001,10 +1001,10 @@ def _scale_bounding_box(
 
 def _scale_point(
     geom: data.Point,
-    time: float = 0,
-    freq: float = 0,
-    time_anchor: float = 1,
-    freq_anchor: float = 1,
+    time: float = 1,
+    freq: float = 1,
+    time_anchor: float = 0,
+    freq_anchor: float = 0,
 ) -> data.Point:
     geom_time, geom_freq = geom.coordinates
     return data.Point(

--- a/tests/test_geometry/test_conversion.py
+++ b/tests/test_geometry/test_conversion.py
@@ -87,3 +87,113 @@ def test_multipolygon_is_converted_to_shapely():
     assert isinstance(geom, shapely.Geometry)
     assert geom.geom_type == "MultiPolygon"
     assert multipolygon.model_dump_json() == shapely.to_geojson(geom)
+
+
+def test_shapely_point_is_converted_to_point():
+    """Test that a Shapely Point is converted to a Point."""
+    # Given
+    point = data.Point(coordinates=[1, 2])
+    shapely_geom = geometry.geometry_to_shapely(point)
+
+    # When
+    converted_point = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_point, data.Point)
+    assert converted_point == point
+
+
+def test_shapely_linestring_is_converted_to_linestring():
+    """Test that a Shapely LineString is converted to a LineString."""
+    # Given
+    linestring = data.LineString(coordinates=[[1, 2], [3, 4]])
+    shapely_geom = geometry.geometry_to_shapely(linestring)
+
+    # When
+    converted_linestring = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_linestring, data.LineString)
+    assert converted_linestring == linestring
+
+
+def test_shapely_polygon_is_converted_to_polygon():
+    """Test that a Shapely Polygon is converted to a Polygon."""
+    # Given
+    polygon = data.Polygon(coordinates=[[[1, 2], [3, 4], [5, 6], [1, 2]]])
+    shapely_geom = geometry.geometry_to_shapely(polygon)
+
+    # When
+    converted_polygon = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_polygon, data.Polygon)
+    assert converted_polygon == polygon
+
+
+def test_shapely_polygon_with_hole_is_converted_to_polygon():
+    """Test that a Shapely Polygon with a hole is converted to a Polygon."""
+    # Given
+    polygon = data.Polygon(
+        coordinates=[
+            [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]],
+            [[2, 2], [2, 8], [8, 8], [8, 2], [2, 2]],
+        ]
+    )
+    shapely_geom = geometry.geometry_to_shapely(polygon)
+
+    # When
+    converted_polygon = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_polygon, data.Polygon)
+    assert converted_polygon == polygon
+
+
+def test_shapely_multipoint_is_converted_to_multipoint():
+    """Test that a Shapely MultiPoint is converted to a MultiPoint."""
+    # Given
+    multipoint = data.MultiPoint(coordinates=[[1, 2], [3, 4]])
+    shapely_geom = geometry.geometry_to_shapely(multipoint)
+
+    # When
+    converted_multipoint = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_multipoint, data.MultiPoint)
+    assert converted_multipoint == multipoint
+
+
+def test_shapely_multilinestring_is_converted_to_multilinestring():
+    """Test that a Shapely MultiLineString is converted to a MultiLineString."""
+    # Given
+    multilinestring = data.MultiLineString(
+        coordinates=[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+    )
+    shapely_geom = geometry.geometry_to_shapely(multilinestring)
+
+    # When
+    converted_multilinestring = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_multilinestring, data.MultiLineString)
+    assert converted_multilinestring == multilinestring
+
+
+def test_shapely_multipolygon_is_converted_to_multipolygon():
+    """Test that a Shapely MultiPolygon is converted to a MultiPolygon."""
+    # Given
+    multipolygon = data.MultiPolygon(
+        coordinates=[
+            [[[1, 2], [3, 4], [5, 6], [1, 2]]],
+            [[[7, 8], [9, 10], [11, 12], [7, 8]]],
+        ]
+    )
+    shapely_geom = geometry.geometry_to_shapely(multipolygon)
+
+    # When
+    converted_multipolygon = geometry.shapely_to_geometry(shapely_geom)
+
+    # Then
+    assert isinstance(converted_multipolygon, data.MultiPolygon)
+    assert converted_multipolygon == multipolygon

--- a/tests/test_geometry/test_operations.py
+++ b/tests/test_geometry/test_operations.py
@@ -18,6 +18,8 @@ from soundevent.geometry.operations import (
     have_temporal_overlap,
     is_in_clip,
     rasterize,
+    scale_geometry,
+    shift_geometry,
 )
 
 
@@ -578,3 +580,230 @@ def test_group_sound_events_transitive_similarity(recording: data.Recording):
     sequences = group_sound_events(sound_events, comparison_fn)
     assert len(sequences) == 1
     assert len(sequences[0].sound_events) == 3  # All in the same group
+
+
+def test_shift_point_geometry():
+    """Test that shift_geometry works with Point geometries."""
+    geom = data.Point(coordinates=[1, 2])
+    shifted_geom = shift_geometry(geom, time=1, freq=2)
+    assert shifted_geom == data.Point(coordinates=[2, 4])
+
+    shifted_geom = shift_geometry(geom, time=-1, freq=-1)
+    assert shifted_geom == data.Point(coordinates=[0, 1])
+
+    shifted_geom = shift_geometry(geom, time=0, freq=0)
+    assert shifted_geom == geom
+
+    shifted_geom = shift_geometry(geom, time=1)
+    assert shifted_geom == data.Point(coordinates=[2, 2])
+
+    shifted_geom = shift_geometry(geom, freq=1)
+    assert shifted_geom == data.Point(coordinates=[1, 3])
+
+
+def test_shift_bounding_box_geometry():
+    """Test that shift_geometry works with BoundingBox geometries."""
+    geom = data.BoundingBox(coordinates=[1, 2, 3, 4])
+    shifted_geom = shift_geometry(geom, time=1, freq=2)
+    assert shifted_geom == data.BoundingBox(coordinates=[2, 4, 4, 6])
+
+    shifted_geom = shift_geometry(geom, time=-1, freq=-1)
+    assert shifted_geom == data.BoundingBox(coordinates=[0, 1, 2, 3])
+
+    shifted_geom = shift_geometry(geom, time=0, freq=0)
+    assert shifted_geom == geom
+
+    shifted_geom = shift_geometry(geom, time=1)
+    assert shifted_geom == data.BoundingBox(coordinates=[2, 2, 4, 4])
+
+    shifted_geom = shift_geometry(geom, freq=1)
+    assert shifted_geom == data.BoundingBox(coordinates=[1, 3, 3, 5])
+
+
+def test_shift_time_interval_geometry():
+    """Test that shift_geometry works with TimeInterval geometries."""
+    geom = data.TimeInterval(coordinates=[1, 2])
+    shifted_geom = shift_geometry(geom, time=1)
+    assert shifted_geom == data.TimeInterval(coordinates=[2, 3])
+
+    shifted_geom = shift_geometry(geom, time=-1)
+    assert shifted_geom == data.TimeInterval(coordinates=[0, 1])
+
+    shifted_geom = shift_geometry(geom, time=0)
+    assert shifted_geom == geom
+
+    # Freq shift should have no effect
+    shifted_geom = shift_geometry(geom, freq=1)
+    assert shifted_geom == geom
+
+
+def test_shift_time_stamp_geometry():
+    """Test that shift_geometry works with TimeStamp geometries."""
+    geom = data.TimeStamp(coordinates=2)
+    shifted_geom = shift_geometry(geom, time=1)
+    assert shifted_geom == data.TimeStamp(coordinates=3)
+
+    shifted_geom = shift_geometry(geom, time=-1)
+    assert shifted_geom == data.TimeStamp(coordinates=1)
+
+    shifted_geom = shift_geometry(geom, time=0)
+    assert shifted_geom == geom
+
+    # Freq shift should have no effect
+    shifted_geom = shift_geometry(geom, freq=1)
+    assert shifted_geom == geom
+
+
+def test_shift_polygon_geometry():
+    """Test that shift_geometry works with Polygon geometries."""
+    geom = data.Polygon(coordinates=[[[1, 2], [3, 4], [5, 6], [1, 2]]])
+    shifted_geom = shift_geometry(geom, time=1, freq=2)
+    assert shifted_geom == data.Polygon(
+        coordinates=[[[2, 4], [4, 6], [6, 8], [2, 4]]]
+    )
+
+
+def test_shift_linestring_geometry():
+    """Test that shift_geometry works with LineString geometries."""
+    geom = data.LineString(coordinates=[[1, 2], [3, 4]])
+    shifted_geom = shift_geometry(geom, time=-1, freq=-2)
+    assert shifted_geom == data.LineString(coordinates=[[0, 0], [2, 2]])
+
+
+def test_scale_point_geometry():
+    """Test that scale_geometry works with Point geometries."""
+    geom = data.Point(coordinates=[10, 20])
+
+    # Scale > 1
+    scaled_geom = scale_geometry(geom, time=2, freq=3)
+    assert scaled_geom == data.Point(coordinates=[20, 60])
+
+    # Scale < 1
+    scaled_geom = scale_geometry(geom, time=0.5, freq=0.25)
+    assert scaled_geom == data.Point(coordinates=[5, 5])
+
+    # Scale == 1
+    scaled_geom = scale_geometry(geom, time=1, freq=1)
+    assert scaled_geom == geom
+
+    # Scale with anchor
+    scaled_geom = scale_geometry(
+        geom, time=2, freq=2, time_anchor=10, freq_anchor=20
+    )
+    assert scaled_geom == data.Point(coordinates=[10, 20])
+
+    scaled_geom = scale_geometry(
+        geom, time=2, freq=2, time_anchor=0, freq_anchor=0
+    )
+    assert scaled_geom == data.Point(coordinates=[20, 40])
+
+    # Scale only time
+    scaled_geom = scale_geometry(geom, time=2)
+    assert scaled_geom == data.Point(coordinates=[20, 20])
+
+    # Scale only freq
+    scaled_geom = scale_geometry(geom, freq=2)
+    assert scaled_geom == data.Point(coordinates=[10, 40])
+
+
+def test_scale_bounding_box_geometry():
+    """Test that scale_geometry works with BoundingBox geometries."""
+    geom = data.BoundingBox(coordinates=[10, 20, 30, 40])
+
+    # Scale > 1
+    scaled_geom = scale_geometry(geom, time=2, freq=3)
+    assert scaled_geom == data.BoundingBox(coordinates=[20, 60, 60, 120])
+
+    # Scale < 1
+    scaled_geom = scale_geometry(geom, time=0.5, freq=0.5)
+    assert scaled_geom == data.BoundingBox(coordinates=[5, 10, 15, 20])
+
+    # Scale with anchor at origin
+    scaled_geom = scale_geometry(
+        geom, time=2, freq=2, time_anchor=0, freq_anchor=0
+    )
+    assert scaled_geom == data.BoundingBox(coordinates=[20, 40, 60, 80])
+
+    # Scale with anchor at center
+    center_time = (10 + 30) / 2  # 20
+    center_freq = (20 + 40) / 2  # 30
+    scaled_geom = scale_geometry(
+        geom, time=2, freq=2, time_anchor=center_time, freq_anchor=center_freq
+    )
+    assert scaled_geom == data.BoundingBox(coordinates=[0, 10, 40, 50])
+
+    # Scale only time
+    scaled_geom = scale_geometry(geom, time=2)
+    assert scaled_geom == data.BoundingBox(coordinates=[20, 20, 60, 40])
+
+
+def test_scale_time_interval_geometry():
+    """Test that scale_geometry works with TimeInterval geometries."""
+    geom = data.TimeInterval(coordinates=[10, 20])
+
+    # Scale > 1
+    scaled_geom = scale_geometry(geom, time=2)
+    assert scaled_geom == data.TimeInterval(coordinates=[20, 40])
+
+    # Scale < 1
+    scaled_geom = scale_geometry(geom, time=0.5)
+    assert scaled_geom == data.TimeInterval(coordinates=[5, 10])
+
+    # Scale with anchor
+    scaled_geom = scale_geometry(geom, time=2, time_anchor=10)
+    assert scaled_geom == data.TimeInterval(coordinates=[10, 30])
+
+    # Freq scale should have no effect
+    scaled_geom = scale_geometry(geom, freq=2, freq_anchor=100)
+    assert scaled_geom == geom
+
+
+def test_scale_time_stamp_geometry():
+    """Test that scale_geometry works with TimeStamp geometries."""
+    geom = data.TimeStamp(coordinates=10)
+
+    # Scale > 1
+    scaled_geom = scale_geometry(geom, time=2)
+    assert scaled_geom == data.TimeStamp(coordinates=20)
+
+    # Scale < 1
+    scaled_geom = scale_geometry(geom, time=0.5)
+    assert scaled_geom == data.TimeStamp(coordinates=5)
+
+    # Scale with anchor
+    scaled_geom = scale_geometry(geom, time=2, time_anchor=10)
+    assert scaled_geom == data.TimeStamp(coordinates=10)
+
+    # Freq scale should have no effect
+    scaled_geom = scale_geometry(geom, freq=2, freq_anchor=100)
+    assert scaled_geom == geom
+
+
+def test_scale_polygon_geometry():
+    """Test that scale_geometry works with Polygon geometries."""
+    geom = data.Polygon(
+        coordinates=[[[10, 20], [30, 20], [20, 40], [10, 20]]]
+    )
+
+    # Uniform scale > 1
+    scaled_geom = scale_geometry(geom, time=2, freq=2)
+    assert scaled_geom == data.Polygon(
+        coordinates=[[[20, 40], [60, 40], [40, 80], [20, 40]]]
+    )
+
+    # With anchor
+    scaled_geom = scale_geometry(
+        geom, time=2, freq=2, time_anchor=10, freq_anchor=20
+    )
+    assert scaled_geom == data.Polygon(
+        coordinates=[[[10, 20], [50, 20], [30, 60], [10, 20]]]
+    )
+
+
+def test_scale_multipoint_geometry():
+    """Test that scale_geometry works with MultiPoint geometries."""
+    geom = data.MultiPoint(coordinates=[[10, 20], [30, 40]])
+
+    # Different factors
+    scaled_geom = scale_geometry(geom, time=2, freq=0.5)
+    assert scaled_geom == data.MultiPoint(coordinates=[[20, 10], [60, 20]])

--- a/tests/test_geometry/test_operations.py
+++ b/tests/test_geometry/test_operations.py
@@ -852,9 +852,7 @@ def test_scale_time_stamp_geometry():
 
 def test_scale_polygon_geometry():
     """Test that scale_geometry works with Polygon geometries."""
-    geom = data.Polygon(
-        coordinates=[[[10, 20], [30, 20], [20, 40], [10, 20]]]
-    )
+    geom = data.Polygon(coordinates=[[[10, 20], [30, 20], [20, 40], [10, 20]]])
 
     # Uniform scale > 1
     scaled_geom = scale_geometry(geom, time=2, freq=2)


### PR DESCRIPTION
This PR introduces two new transformation functions for geometries: `shift_geometry` and `scale_geometry`.

### New Features

-   **`shift_geometry`**: Translates a geometry by a given offset in the time and frequency dimensions.
-   **`scale_geometry`**: Scales a geometry by a given factor, with respect to an anchor point.

These functions support all standard geometry types, including `Point`, `BoundingBox`, `TimeInterval`, `TimeStamp`, and `shapely`-compatible objects like `Polygon` and `LineString`.

### Testing

-   Added a comprehensive test suite for both `shift_geometry` and `scale_geometry`, covering all supported geometry types and various transformation scenarios.
-   All new and existing tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added conversion from Shapely geometries into app geometries, supporting points, lines, and polygons (including multi-variants).
  - Introduced geometry transformations: shift and scale along time and frequency axes, with optional anchors for precise control.
- Refactor
  - Streamlined geometry buffering by using a direct conversion path for improved reliability.
- Tests
  - Added comprehensive tests for shifting and scaling across all supported geometry types, including edge cases and anchor-based behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->