### PR TITLE
Refactor: Loosen validation of geometry objects

### DIFF
--- a/src/soundevent/data/geometries.py
+++ b/src/soundevent/data/geometries.py
@@ -621,7 +621,7 @@ class MultiLineString(BaseGeometry):
             line = v[index]
             start_time = line[0][0]
             end_time = line[-1][0]
-            if not (start_time < end_time):
+            if end_time < start_time:
                 v[index] = line[::-1]
         return v
 

--- a/tests/test_data/test_geometry.py
+++ b/tests/test_data/test_geometry.py
@@ -260,9 +260,8 @@ def test_geometry_validate_fails_with_invalid_geometry():
         data.geometry_validate(obj, mode="dict")
 
 
-def test_invalid_time_interval():
-    """Test that an invalid time interval fails."""
-    # sorts time
+def test_time_interval_sorts_start_end():
+    """TimeInterval auto-sorts [start, end] when start > end."""
     geom = data.TimeInterval(coordinates=[2, 1])
     assert geom.coordinates == [1, 2]
 
@@ -283,6 +282,32 @@ def test_invalid_linestring():
     # Has to have at least two points
     with pytest.raises(ValueError):
         data.LineString(coordinates=[[0, 1]])
+
+
+def test_invalid_multipoint():
+    # Has to have at least one point
+    with pytest.raises(ValueError):
+        data.MultiPoint(coordinates=[])
+
+
+def test_invalid_polygon():
+    # Has to have at least one ring
+    with pytest.raises(ValueError):
+        data.Polygon(coordinates=[])
+
+    # Has to have at least three points
+    with pytest.raises(ValueError):
+        data.Polygon(coordinates=[[[0, 1], [2, 3]]])
+
+    # Rings need to have at least three points
+    with pytest.raises(ValueError):
+        data.Polygon(coordinates=[[[0, 1], [2, 3], [4, 0]], [[1, 1], [1, 2]]])
+
+
+def test_invalid_multiline():
+    # Has to have at least one linestring
+    with pytest.raises(ValueError):
+        data.LineString(coordinates=[])
 
 
 def test_fixes_linestring_order():


### PR DESCRIPTION
Currently, the Geometry objects in soundevent perform quite stringent validations. In particular, all geometric objects are expected to have time coordinates that are positive, and frequency coordinates that are also positive and less than a maximum value.

This validation is too strict for many operations that require transforming geometries, leading to a lot of error handling in downstream uses. This also limits the way users can use the Geometry objects and how they interpret the coordinates. For example, if one wanted to use relative coordinates (to an anchor point), this would not be possible.

This PR proposes to relax these validations, leaving the Geometry objects as relatively simple data containers and letting downstream users validate the data when needed. Validations related to the coordinates objects being actually valid for the type of geometric object are kept, but no others.

**Changes:**

*   Removed validation for positive time and frequency coordinates in all geometry objects.
*   `TimeInterval` now automatically sorts the start and end times if they are in the wrong order.
*   `BoundingBox` now automatically sorts the time and frequency coordinates if they are in the wrong order.
*   `MultiLineString` now automatically reverses the order of points in a line if they are not ordered by time.
*   Updated tests to reflect the new behavior.

This change will provide more flexibility to the users of the library and simplify the implementation of downstream applications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation is more permissive: negative times/frequencies are accepted and many inputs are no longer rejected.
  * Time intervals, line-based geometries and bounding boxes auto-normalize (start ≤ end).

* **Documentation**
  * Validation/error messages simplified and generalized for geometry inputs.

* **Tests**
  * Tests updated to reflect normalization behavior; removed tests that expected errors for negative or inverted values and expanded invalid-shape coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->